### PR TITLE
Generate sitemap xml files and save to temp dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 coverage
 settings.json
 dist/*.zip
+tmp

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 node_modules
 coverage
 settings.json
-dist/*.zip
+dist
 tmp

--- a/README.md
+++ b/README.md
@@ -1,3 +1,23 @@
 # collectionsonline-sitemap
 
 An AWS lambda for generating a sitemap.xml and storing it to S3.
+
+## Getting started
+
+1. Install [Node.js](https://nodejs.org/en/) 4.x
+2. Install dependencies: `npm install`
+3. Copy `settings.json.template` to `settings.json` in the project route
+
+## Settings
+
+### `siteUrl`
+The base URL of the collections online website.
+
+### `sitemapUrl`
+The base URL of the S3 bucket where the sitemaps are stored.
+
+### `maxSitemapUrls`
+The maximum number of URLs to include in each sitemap file (50,000 is the spec max)
+
+### `pageSize`
+The size of the pages retrieved from elasticsearch.

--- a/index.js
+++ b/index.js
@@ -1,5 +1,56 @@
+const Path = require('path');
+const mkdirp = require('mkdirp');
+const Client = require('elasticsearch').Client;
+const Async = require('async');
+const scrollIndex = require('./lib/scroll-index');
+const hitToSitemapEntry = require('./lib/hit-to-sitemap-entry');
+const createSitemap = require('./lib/create-sitemap');
+const createSitemapIndex = require('./lib/create-sitemap-index');
 const settings = require('./settings.json');
 
+const SITEMAPS_PATH = Path.join(__dirname, 'tmp');
+
 exports.handler = (event, context) => {
-  console.log('MY LAMBDA', settings);
+  Async.waterfall([
+
+    // Create tmp dir for storing the created sitemaps
+    (cb) => mkdirp(SITEMAPS_PATH, (err) => cb(err)),
+
+    // Create each sitemap
+    (cb) => {
+      const elastic = new Client(settings.elasticsearch);
+      const sitemaps = [];
+
+      scrollIndex(elastic, {
+        batchSize: settings.maxSitemapUrls,
+        fields: ['admin.modified'],
+
+        // Transform a hit into a sitemap entry
+        onHit: (hit) => hitToSitemapEntry(hit, settings.siteUrl),
+
+        // Transform a batch of sitemap entries into a sitemap.xml
+        onBatch: (entries, cb) => {
+          const filename = `sitemap-${sitemaps.length}.xml`;
+          const filePath = Path.join(SITEMAPS_PATH, filename);
+
+          createSitemap(entries, filePath, (err) => {
+            if (err) return cb(err);
+            console.log(`${filename} created`);
+            sitemaps.push(filename);
+            cb();
+          });
+        }
+      }, (err) => cb(err, sitemaps));
+    },
+
+    // Create sitemap index file
+    (sitemaps, cb) => {
+      const filePath = Path.join(SITEMAPS_PATH, 'sitemap.xml');
+      createSitemapIndex(sitemaps, settings.sitemapUrl, filePath, cb);
+    }
+
+  ], (err) => {
+    if (err) throw err;
+    console.log('sitemap.xml created');
+  });
 };

--- a/lib/create-sitemap-index.js
+++ b/lib/create-sitemap-index.js
@@ -1,0 +1,16 @@
+const Fs = require('fs');
+const convert = require('data2xml')();
+
+module.exports = (sitemapFilenames, sitemapUrl, filePath, cb) => {
+  const now = new Date().toISOString();
+
+  const xml = convert('sitemapindex', {
+    _attr: { xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9' },
+    sitemap: sitemapFilenames.map((filename) => ({
+      loc: `${sitemapUrl}/${filename}`,
+      lastmod: now
+    }))
+  });
+
+  Fs.writeFile(filePath, xml, cb);
+};

--- a/lib/create-sitemap.js
+++ b/lib/create-sitemap.js
@@ -1,0 +1,15 @@
+const Fs = require('fs');
+const convert = require('data2xml')();
+
+module.exports = (entries, filePath, cb) => {
+  const xml = convert('urlset', {
+    _attr: {
+      xmlns: 'http://www.sitemaps.org/schemas/sitemap/0.9',
+      'xmlns:xsi': 'http://www.w3.org/2001/XMLSchema-instance',
+      'xsi:schemaLocation': 'http://www.sitemaps.org/schemas/sitemap/0.9 http://www.sitemaps.org/schemas/sitemap/0.9/sitemap.xsd'
+    },
+    url: entries
+  });
+
+  Fs.writeFile(filePath, xml, cb);
+};

--- a/lib/hit-to-sitemap-entry.js
+++ b/lib/hit-to-sitemap-entry.js
@@ -1,0 +1,12 @@
+const TypeMapping = require('./type-mapping');
+
+module.exports = (hit, siteUrl) => {
+  const type = TypeMapping.toExternal(hit._type);
+  const id = TypeMapping.toExternal(hit._id);
+
+  return ({
+    loc: `${siteUrl}/${type}/${id}`,
+    lastmod: new Date(hit._source.admin.modified).toISOString(),
+    changefreq: 'daily'
+  });
+};

--- a/lib/hit-to-sitemap-entry.js
+++ b/lib/hit-to-sitemap-entry.js
@@ -4,9 +4,9 @@ module.exports = (hit, siteUrl) => {
   const type = TypeMapping.toExternal(hit._type);
   const id = TypeMapping.toExternal(hit._id);
 
-  return ({
+  return {
     loc: `${siteUrl}/${type}/${id}`,
     lastmod: new Date(hit._source.admin.modified).toISOString(),
     changefreq: 'daily'
-  });
+  };
 };

--- a/lib/scroll-index.js
+++ b/lib/scroll-index.js
@@ -1,0 +1,72 @@
+const Async = require('async');
+
+// Scroll over the elasticsearch index
+// https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
+module.exports = (elastic, opts, cb) => {
+  opts = opts || {};
+  opts.batchSize = opts.batchSize || 25;
+
+  const onHit = opts.onHit || ((hit) => hit);
+  const onBatch = opts.onBatch || null;
+
+  var batch = [];
+  var numProcessed = 0;
+
+  const searchOpts = {
+    index: 'smg',
+    size: 10000,
+    scroll: '30s', // Set to 30 seconds because we are calling right back
+    search_type: 'scan',
+    body: {
+      query: {
+        bool: {
+          must: {
+            match_all: {}
+          },
+          filter: {
+            terms: {
+              'type.base': ['agent', 'archive', 'object']
+            }
+          }
+        }
+      }
+    }
+  };
+
+  if (opts.fields) {
+    searchOpts._source = opts.fields;
+  }
+
+  elastic.search(searchOpts, function scroll (err, res) {
+    if (err) throw err;
+
+    const iterate = (hit, cb) => {
+      batch.push(onHit(hit));
+      numProcessed++;
+
+      if (onBatch && batch.length >= opts.batchSize) {
+        onBatch(batch.slice(0, opts.batchSize), (err) => {
+          if (err) return cb(err);
+          batch = batch.slice(opts.batchSize);
+          cb();
+        });
+      } else {
+        Async.setImmediate(cb);
+      }
+    };
+
+    Async.eachSeries(res.hits.hits, iterate, (err) => {
+      if (err) return cb(err);
+
+      if (res.hits.total === numProcessed) {
+        if (onBatch && batch.length) { // Send final batch if there is some
+          return onBatch(batch, (err) => cb(err, []));
+        } else {
+          return cb(null, batch);
+        }
+      }
+
+      elastic.scroll({ scrollId: res._scroll_id, scroll: '30s' }, scroll);
+    });
+  });
+};

--- a/lib/type-mapping.js
+++ b/lib/type-mapping.js
@@ -1,0 +1,13 @@
+// Mapping internal types to external types (plurals first!)
+const inToExMap = {
+  objects: 'objects',
+  object: 'objects',
+  agents: 'people',
+  agent: 'people',
+  archives: 'documents',
+  archive: 'documents'
+};
+
+const inToExRegx = new RegExp('(' + Object.keys(inToExMap).join('|') + ')');
+
+exports.toExternal = (type) => (type + '').replace(inToExRegx, (match) => inToExMap[match]);

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "npm run clean && npm run build:zip",
     "build:zip": "VERSION=`getversion` && zip -q -r \"dist/sitemap-v$VERSION.zip\" * -x dist/\\* coverage/\\*",
     "clean": "rm -rf dist/*",
-    "test": "semistandard && istanbul cover tape test.js"
+    "test": "semistandard && istanbul cover tape 'test/*.test.js'"
   },
   "author": "Science Museum Group",
   "license": "MIT",
@@ -18,10 +18,12 @@
     "mkdirp": "^0.5.1"
   },
   "devDependencies": {
+    "faker": "^3.1.0",
     "getversion": "^0.1.1",
     "istanbul": "^0.4.4",
     "semistandard": "^8.0.0",
-    "tape": "^4.6.0"
+    "tape": "^4.6.0",
+    "xml2js": "^0.4.17"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,15 +9,25 @@
     "test": "semistandard && istanbul cover tape test.js"
   },
   "author": "Science Museum Group",
-  "license": "ISC",
+  "license": "MIT",
   "dependencies": {
     "async": "^2.0.1",
-    "elasticsearch": "^11.0.1"
+    "data2xml": "^1.2.5",
+    "elasticsearch": "^11.0.1",
+    "mkdirp": "^0.5.1"
   },
   "devDependencies": {
     "getversion": "^0.1.1",
     "istanbul": "^0.4.4",
     "semistandard": "^8.0.0",
     "tape": "^4.6.0"
-  }
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/TheScienceMuseum/collectionsonline-sitemap.git"
+  },
+  "bugs": {
+    "url": "https://github.com/TheScienceMuseum/collectionsonline-sitemap/issues"
+  },
+  "homepage": "https://github.com/TheScienceMuseum/collectionsonline-sitemap#readme"
 }

--- a/package.json
+++ b/package.json
@@ -4,8 +4,9 @@
   "description": "An AWS lambda for generating a sitemap.xml for the collections online website",
   "main": "index.js",
   "scripts": {
-    "build": "VERSION=`getversion` && zip -q -r \"dist/sitemap-v$VERSION.zip\" *",
-    "clean": "rm dist/*.zip",
+    "build": "npm run clean && npm run build:zip",
+    "build:zip": "VERSION=`getversion` && zip -q -r \"dist/sitemap-v$VERSION.zip\" * -x dist/\\* coverage/\\*",
+    "clean": "rm -rf dist/*",
     "test": "semistandard && istanbul cover tape test.js"
   },
   "author": "Science Museum Group",

--- a/settings.json.template
+++ b/settings.json.template
@@ -1,4 +1,8 @@
 {
+  "siteUrl": "http://localhost:8000",
+  "sitemapUrl": "http://localhost:8000",
+  "maxSitemapUrls": 50000,
+  "pageSize": 10000,
   "elasticsearch": {
     "apiVersion": "2.3",
     "host": "",

--- a/test.js
+++ b/test.js
@@ -1,0 +1,9 @@
+const test = require('tape');
+const lambda = require('./');
+
+test('Should do something', (t) => {
+  t.plan(1);
+  lambda.handler();
+  t.ok(true);
+  t.end();
+});

--- a/test.js
+++ b/test.js
@@ -1,9 +1,0 @@
-const test = require('tape');
-const lambda = require('./');
-
-test('Should do something', (t) => {
-  t.plan(1);
-  lambda.handler();
-  t.ok(true);
-  t.end();
-});

--- a/test.js
+++ b/test.js
@@ -1,0 +1,1 @@
+require('./').handler();

--- a/test/create-sitemap-index.test.js
+++ b/test/create-sitemap-index.test.js
@@ -1,0 +1,38 @@
+const Fs = require('fs');
+const Path = require('path');
+const test = require('tape');
+const mkdirp = require('mkdirp');
+const parseString = require('xml2js').parseString;
+const Faker = require('faker');
+const createSitemapIndex = require('../lib/create-sitemap-index');
+
+test('Should create an xml sitemap index', (t) => {
+  t.plan(8);
+
+  const sitemapUrl = Faker.internet.url();
+  const sitemapFilenames = [Faker.system.fileName(), Faker.system.fileName()];
+  var filePath = Path.resolve(__dirname, '..', 'tmp');
+  mkdirp.sync(filePath);
+  filePath = Path.join(filePath, `sitemap-${Date.now()}.xml`);
+
+  createSitemapIndex(sitemapFilenames, sitemapUrl, filePath, (err) => {
+    t.ifError(err, 'No error creating sitemap index');
+
+    const xml = Fs.readFileSync(filePath, 'utf-8');
+
+    parseString(xml, (err, obj) => {
+      t.ifError(err, 'No error parsing sitemap index');
+
+      t.ok(obj.sitemapindex, 'sitemapindex key was present');
+      t.ok(obj.sitemapindex.sitemap, 'sitemapindex.sitemap key was present');
+
+      t.ok(obj.sitemapindex.sitemap[0].loc[0], 'Sitemap has location key');
+      t.equal(obj.sitemapindex.sitemap[0].loc[0], `${sitemapUrl}/${sitemapFilenames[0]}`, 'Sitemap has expected location value');
+
+      t.ok(obj.sitemapindex.sitemap[1].loc[0], 'Sitemap has location key');
+      t.equal(obj.sitemapindex.sitemap[1].loc[0], `${sitemapUrl}/${sitemapFilenames[1]}`, 'Sitemap has expected location value');
+
+      t.end();
+    });
+  });
+});

--- a/test/create-sitemap.test.js
+++ b/test/create-sitemap.test.js
@@ -1,0 +1,49 @@
+const Fs = require('fs');
+const Path = require('path');
+const test = require('tape');
+const mkdirp = require('mkdirp');
+const parseString = require('xml2js').parseString;
+const createSitemap = require('../lib/create-sitemap');
+const fakeSitemapEntry = require('./helpers/fake-sitemap-entry');
+
+test('Should create an xml sitemap', (t) => {
+  t.plan(16);
+
+  const entries = [fakeSitemapEntry(), fakeSitemapEntry()];
+  var filePath = Path.resolve(__dirname, '..', 'tmp');
+  mkdirp.sync(filePath);
+  filePath = Path.join(filePath, `sitemap-${Date.now()}.xml`);
+
+  createSitemap(entries, filePath, (err) => {
+    t.ifError(err, 'No error creating sitemap');
+
+    const xml = Fs.readFileSync(filePath, 'utf-8');
+
+    parseString(xml, (err, obj) => {
+      t.ifError(err, 'No error parsing sitemap');
+
+      t.ok(obj.urlset, 'urlset key was present');
+      t.ok(obj.urlset.url, 'urlset.url key was present');
+
+      t.ok(obj.urlset.url[0].loc[0], 'Entry has location key');
+      t.equal(obj.urlset.url[0].loc[0], entries[0].loc, 'Entry has expected location value');
+
+      t.ok(obj.urlset.url[0].lastmod[0], 'Entry has last modified key');
+      t.equal(obj.urlset.url[0].lastmod[0], entries[0].lastmod, 'Entry has expected last modified value');
+
+      t.ok(obj.urlset.url[0].changefreq[0], 'Entry has change frequency key');
+      t.equal(obj.urlset.url[0].changefreq[0], entries[0].changefreq, 'Entry has expected change frequency value');
+
+      t.ok(obj.urlset.url[1].loc[0], 'Entry has location key');
+      t.equal(obj.urlset.url[1].loc[0], entries[1].loc, 'Entry has expected location value');
+
+      t.ok(obj.urlset.url[1].lastmod[0], 'Entry has last modified key');
+      t.equal(obj.urlset.url[1].lastmod[0], entries[1].lastmod, 'Entry has expected last modified value');
+
+      t.ok(obj.urlset.url[1].changefreq[0], 'Entry has change frequency key');
+      t.equal(obj.urlset.url[1].changefreq[0], entries[1].changefreq, 'Entry has expected change frequency value');
+
+      t.end();
+    });
+  });
+});

--- a/test/helpers/fake-sitemap-entry.js
+++ b/test/helpers/fake-sitemap-entry.js
@@ -1,0 +1,7 @@
+const Faker = require('faker');
+
+module.exports = () => ({
+  loc: Faker.internet.url(),
+  lastmod: Faker.date.past().toISOString(),
+  changefreq: 'daily'
+});

--- a/test/hit-to-sitemap-entry.test.js
+++ b/test/hit-to-sitemap-entry.test.js
@@ -1,0 +1,35 @@
+const test = require('tape');
+const hitToSitemapEntry = require('../lib/hit-to-sitemap-entry');
+
+test('Should convert hit document to sitemap entry', (t) => {
+  t.plan(6);
+
+  const id = 'smg-agent-12345';
+  const type = 'agent';
+  const modified = Date.now();
+
+  const hit = {
+    _id: id,
+    _type: type,
+    _source: {
+      admin: {
+        modified: modified
+      }
+    }
+  };
+
+  const url = 'http://localhost';
+
+  const entry = hitToSitemapEntry(hit, url);
+
+  t.ok(entry.loc, 'Entry has location key');
+  t.equal(entry.loc, `${url}/people/smg-people-12345`, 'Entry has expected location value');
+
+  t.ok(entry.lastmod, 'Entry has last modified key');
+  t.equal(entry.lastmod, new Date(modified).toISOString(), 'Entry has expected last modified value');
+
+  t.ok(entry.changefreq, 'Entry has change frequency key');
+  t.equal(entry.changefreq, 'daily', 'Entry has expected change frequency value');
+
+  t.end();
+});

--- a/test/type-mapping.test.js
+++ b/test/type-mapping.test.js
@@ -1,0 +1,19 @@
+const test = require('tape');
+const TypeMapping = require('../lib/type-mapping');
+
+test('Should convert to external types', (t) => {
+  t.plan(6);
+  t.equal(TypeMapping.toExternal('agent'), 'people');
+  t.equal(TypeMapping.toExternal('agents'), 'people');
+  t.equal(TypeMapping.toExternal('object'), 'objects');
+  t.equal(TypeMapping.toExternal('objects'), 'objects');
+  t.equal(TypeMapping.toExternal('archive'), 'documents');
+  t.equal(TypeMapping.toExternal('archives'), 'documents');
+  t.end();
+});
+
+test('Should leave unknown intact', (t) => {
+  t.plan(1);
+  t.equal(TypeMapping.toExternal('FOOBAR'), 'FOOBAR');
+  t.end();
+});


### PR DESCRIPTION
This PR simply adds functionality to generate XML sitemap files from the collectionsonline elasticsearch index. It saves them to a temporary directory. Next step is to upload these to S3, but I'm opening this PR now for review since it is already big.
1. Add your `settings.json` file by copying `settings.json.template`.
2. (Temporarily) use `node test.js` to test operation
3. Sitemap files should appear in tmp/sitemap*.xml
