### PR TITLE
Add SITEMAP_MIN_LASTMOD env vars to control Google recrawl

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,18 @@ When set, any record whose `processed` date is older than the value will have it
 
 **Usage:**
 1. Set `SITEMAP_MIN_LASTMOD` on the Lambda environment to the date of your design change
-2. Run the sitemap generator — all pages will appear updated to Google
-3. Wait for Google to recrawl (check Search Console)
-4. Remove the environment variable once recrawling is complete
+2. Optionally set `SITEMAP_MIN_LASTMOD_EXCLUDE` to defer expensive record types (see below)
+3. Run the sitemap generator — all pages will appear updated to Google
+4. Wait for Google to recrawl (check Search Console)
+5. Remove the environment variable(s) once recrawling is complete
+
+### `SITEMAP_MIN_LASTMOD_EXCLUDE`
+
+A comma-separated list of record types to exempt from the `SITEMAP_MIN_LASTMOD` floor. Pages of these types will keep their original `lastmod` date and will not be marked as recently updated.
+
+**Format:** One or more of `objects`, `people`, `documents` — e.g. `documents` or `documents,people`
+
+**Example use case:** Documents are large and expensive for Google to reprocess. Set `SITEMAP_MIN_LASTMOD_EXCLUDE=documents` to reindex objects and people first, then remove the exclusion in a later run to pick up documents.
 
 ## Deploy
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,22 @@ Connection details for the elasticsearch index to use.
 ### `s3`
 AWS S3 bucket name and access credentials for where to put the sitemap files. These credentials should have permissions to write to and set permissions on the bucket.
 
+## Environment variables
+
+### `SITEMAP_MIN_LASTMOD`
+
+Set this on the Lambda to force Google to recrawl all pages after a design change (e.g. a new page layout or component).
+
+When set, any record whose `processed` date is older than the value will have its `lastmod` floored to this date, making Google treat the page as recently updated. Records that are already newer than this date are unaffected.
+
+**Format:** ISO 8601 date string, e.g. `2024-06-01T00:00:00.000Z`
+
+**Usage:**
+1. Set `SITEMAP_MIN_LASTMOD` on the Lambda environment to the date of your design change
+2. Run the sitemap generator — all pages will appear updated to Google
+3. Wait for Google to recrawl (check Search Console)
+4. Remove the environment variable once recrawling is complete
+
 ## Deploy
 
 1. Install just the dependencies needed for running the lambda

--- a/handler.js
+++ b/handler.js
@@ -9,6 +9,12 @@ const uploadFiles = require('./lib/upload-files');
 const addKeySerps = require('./lib/add-key-serps');
 
 module.exports = (elastic, s3, settings) => {
+  // SITEMAP_MIN_LASTMOD env var overrides settings — set in Lambda to force
+  // Google to recrawl all pages e.g. after a design change. Remove once done.
+  if (process.env.SITEMAP_MIN_LASTMOD) {
+    settings = Object.assign({}, settings, { minLastmod: process.env.SITEMAP_MIN_LASTMOD });
+  }
+
   const sitemapDir = Path.join(settings.tmpDir || 'tmp', 'sitemap' + Date.now().toString());
 
   return (event, context, cb) => {

--- a/handler.js
+++ b/handler.js
@@ -15,6 +15,15 @@ module.exports = (elastic, s3, settings) => {
     settings = Object.assign({}, settings, { minLastmod: process.env.SITEMAP_MIN_LASTMOD });
   }
 
+  // SITEMAP_MIN_LASTMOD_EXCLUDE — comma-separated list of types to exempt from
+  // the minLastmod floor (e.g. "documents"). Useful when some record types are
+  // expensive to reprocess and can be deferred to a later recrawl.
+  if (process.env.SITEMAP_MIN_LASTMOD_EXCLUDE) {
+    settings = Object.assign({}, settings, {
+      minLastmodExclude: process.env.SITEMAP_MIN_LASTMOD_EXCLUDE.split(',').map(function (t) { return t.trim(); })
+    });
+  }
+
   const sitemapDir = Path.join(settings.tmpDir || 'tmp', 'sitemap' + Date.now().toString());
 
   return (event, context, cb) => {

--- a/lib/hit-to-sitemap-entry.js
+++ b/lib/hit-to-sitemap-entry.js
@@ -8,7 +8,8 @@ module.exports = (hit, elastic, settings, cb) => {
   var slugValue = hit._source.summary ? slug(hit._source.summary.title, {lower: true}) : false;
   var loc = slugValue ? `${settings.siteUrl}/${type}/${id}/${slugValue}` : `${settings.siteUrl}/${type}/${id}`;
   var lastmodDate = new Date(hit._source['@admin'].processed);
-  if (settings.minLastmod && lastmodDate < new Date(settings.minLastmod)) {
+  var excluded = settings.minLastmodExclude && settings.minLastmodExclude.indexOf(type) !== -1;
+  if (settings.minLastmod && !excluded && lastmodDate < new Date(settings.minLastmod)) {
     lastmodDate = new Date(settings.minLastmod);
   }
   var lastmod = lastmodDate.toISOString();

--- a/lib/hit-to-sitemap-entry.js
+++ b/lib/hit-to-sitemap-entry.js
@@ -7,7 +7,11 @@ module.exports = (hit, elastic, settings, cb) => {
   var id = TypeMapping.toExternal(hit._id);
   var slugValue = hit._source.summary ? slug(hit._source.summary.title, {lower: true}) : false;
   var loc = slugValue ? `${settings.siteUrl}/${type}/${id}/${slugValue}` : `${settings.siteUrl}/${type}/${id}`;
-  var lastmod = new Date(hit._source['@admin'].processed).toISOString();
+  var lastmodDate = new Date(hit._source['@admin'].processed);
+  if (settings.minLastmod && lastmodDate < new Date(settings.minLastmod)) {
+    lastmodDate = new Date(settings.minLastmod);
+  }
+  var lastmod = lastmodDate.toISOString();
   var title = hit._source.summary ? hit._source.summary.title : null;
 
   var ownImages = (hit._source.multimedia || []).reduce(function (acc, media) {

--- a/test/hit-to-sitemap-entry.test.js
+++ b/test/hit-to-sitemap-entry.test.js
@@ -187,6 +187,54 @@ test('Should not apply minLastmod floor when record is newer', (t) => {
   });
 });
 
+test('Should not apply minLastmod floor when type is excluded', (t) => {
+  t.plan(2);
+
+  const oldProcessed = new Date('2020-01-01').getTime();
+  const minLastmod = '2024-06-01T00:00:00.000Z';
+
+  const hit = {
+    _id: 'smg-archive-99',
+    _source: {
+      '@admin': {uid: 'co-archive-99', processed: oldProcessed},
+      '@datatype': {base: 'archive'},
+      summary: {title: 'Old Document'}
+    }
+  };
+
+  const settings = Object.assign({}, testSettings, {minLastmod, minLastmodExclude: ['documents']});
+
+  hitToSitemapEntry(hit, null, settings, (err, entry) => {
+    t.ifError(err, 'No error');
+    t.equal(entry.lastmod, new Date(oldProcessed).toISOString(), 'lastmod is not floored for excluded type');
+    t.end();
+  });
+});
+
+test('Should still apply minLastmod floor to non-excluded types when exclude list is set', (t) => {
+  t.plan(2);
+
+  const oldProcessed = new Date('2020-01-01').getTime();
+  const minLastmod = '2024-06-01T00:00:00.000Z';
+
+  const hit = {
+    _id: 'smg-object-99',
+    _source: {
+      '@admin': {uid: 'co-object-99', processed: oldProcessed},
+      '@datatype': {base: 'object'},
+      summary: {title: 'Old Object'}
+    }
+  };
+
+  const settings = Object.assign({}, testSettings, {minLastmod, minLastmodExclude: ['documents']});
+
+  hitToSitemapEntry(hit, null, settings, (err, entry) => {
+    t.ifError(err, 'No error');
+    t.equal(entry.lastmod, minLastmod, 'lastmod is still floored for non-excluded type');
+    t.end();
+  });
+});
+
 test('Should not include image:image key when no images', (t) => {
   t.plan(2);
 

--- a/test/hit-to-sitemap-entry.test.js
+++ b/test/hit-to-sitemap-entry.test.js
@@ -142,6 +142,51 @@ test('Should merge and deduplicate parent and child images', (t) => {
   });
 });
 
+test('Should apply minLastmod floor when record is older', (t) => {
+  t.plan(3);
+
+  const oldProcessed = new Date('2020-01-01').getTime();
+  const minLastmod = '2024-06-01T00:00:00.000Z';
+
+  const hit = {
+    _id: 'smg-object-old',
+    _source: {
+      '@admin': {uid: 'co-old', processed: oldProcessed},
+      '@datatype': {base: 'object'},
+      summary: {title: 'Old Record'}
+    }
+  };
+
+  hitToSitemapEntry(hit, null, Object.assign({}, testSettings, {minLastmod}), (err, entry) => {
+    t.ifError(err, 'No error');
+    t.equal(entry.lastmod, minLastmod, 'lastmod is floored to minLastmod');
+    t.notEqual(entry.lastmod, new Date(oldProcessed).toISOString(), 'lastmod is not the original processed date');
+    t.end();
+  });
+});
+
+test('Should not apply minLastmod floor when record is newer', (t) => {
+  t.plan(2);
+
+  const recentProcessed = new Date('2025-01-01').getTime();
+  const minLastmod = '2024-06-01T00:00:00.000Z';
+
+  const hit = {
+    _id: 'smg-object-new',
+    _source: {
+      '@admin': {uid: 'co-new', processed: recentProcessed},
+      '@datatype': {base: 'object'},
+      summary: {title: 'New Record'}
+    }
+  };
+
+  hitToSitemapEntry(hit, null, Object.assign({}, testSettings, {minLastmod}), (err, entry) => {
+    t.ifError(err, 'No error');
+    t.equal(entry.lastmod, new Date(recentProcessed).toISOString(), 'lastmod uses record date when newer than minLastmod');
+    t.end();
+  });
+});
+
 test('Should not include image:image key when no images', (t) => {
   t.plan(2);
 


### PR DESCRIPTION
## Summary

Adds two environment variables to the Lambda for forcing Google to recrawl pages after a design change (e.g. a new page layout or component):

- **`SITEMAP_MIN_LASTMOD`** — set a floor date on `lastmod`; any record older than this date will appear updated to Google, prompting a recrawl. Records already newer than the date are unaffected.
- **`SITEMAP_MIN_LASTMOD_EXCLUDE`** — comma-separated list of types (e.g. `documents`) to exempt from the floor, so expensive record types can be deferred to a later run.

Both variables are intended to be temporary — remove them once Google has finished recrawling (monitor via Search Console).

**Example usage:**
```
SITEMAP_MIN_LASTMOD=2026-03-09T00:00:00.000Z
SITEMAP_MIN_LASTMOD_EXCLUDE=documents
```

## Test plan

- [x] All 69 tests pass (`node ./node_modules/.bin/tape 'test/*.test.js'`)
- [x] `minLastmod` floor applied when record is older than the date
- [x] `minLastmod` floor skipped when record is newer than the date
- [x] `minLastmodExclude` exempts the specified type from the floor
- [x] Non-excluded types are still floored when the exclude list is set
- [ ] Deploy to Lambda, set `SITEMAP_MIN_LASTMOD` and verify older records show the floor date in the sitemap