### PR TITLE
Add museums allowlist and named collections sitemap entries

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ Temporary directory where the sitemap files are stored. For running on AWS this 
 ### `elasticsearch`
 Connection details for the elasticsearch index to use.
 
+### `standaloneMuseums`
+An array of museum names that have no individual gallery pages in the index. These are included as top-level `/search/museum/<slug>` URLs even though they don't appear in any combined `"Museum, Gallery"` `ondisplay` entry. Museums that do have gallery pages are detected automatically and do not need to be listed here (though listing them is harmless).
+
 ### `s3`
 AWS S3 bucket name and access credentials for where to put the sitemap files. These credentials should have permissions to write to and set permissions on the bucket.
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Temporary directory where the sitemap files are stored. For running on AWS this 
 ### `elasticsearch`
 Connection details for the elasticsearch index to use.
 
-### `standaloneMuseums`
-An array of museum names that have no individual gallery pages in the index. These are included as top-level `/search/museum/<slug>` URLs even though they don't appear in any combined `"Museum, Gallery"` `ondisplay` entry. Museums that do have gallery pages are detected automatically and do not need to be listed here (though listing them is harmless).
+### `museums`
+The definitive allowlist of valid museum names. Only museums in this list get top-level `/search/museum/<slug>` URLs and gallery/category sub-URLs — all other `ondisplay.value.keyword` values (standalone galleries, non-museum locations, etc.) are ignored. Values must match the exact ES string, e.g. `"Science Museum"` produces `/search/museum/science-museum`.
 
 ### `s3`
 AWS S3 bucket name and access credentials for where to put the sitemap files. These credentials should have permissions to write to and set permissions on the bucket.

--- a/lib/add-key-serps.js
+++ b/lib/add-key-serps.js
@@ -2,6 +2,7 @@ const Async = require('async');
 const getCategories = require('./get-categories');
 const getLocations = require('./get-locations');
 const getCategoriesAtLocations = require('./get-categories-at-locations');
+const getCollections = require('./get-collections');
 
 module.exports = (elastic, settings, sitemaps, cb) => {
   Async.waterfall([
@@ -9,7 +10,9 @@ module.exports = (elastic, settings, sitemaps, cb) => {
 
     (sitemaps, cb) => getLocations(elastic, settings, sitemaps, cb),
 
-    (sitemaps, cb) => getCategoriesAtLocations(elastic, settings, sitemaps, cb)
+    (sitemaps, cb) => getCategoriesAtLocations(elastic, settings, sitemaps, cb),
+
+    (sitemaps, cb) => getCollections(elastic, settings, sitemaps, cb)
 
   ], (err, result) => {
     if (err) console.log(err);

--- a/lib/get-categories-at-locations.js
+++ b/lib/get-categories-at-locations.js
@@ -20,18 +20,13 @@ module.exports = (elastic, settings, sitemaps, cb) => {
     var buckets = data.body.aggregations.display_values.buckets;
     var entries = [];
 
-    // Pass 1: identify museum names (same logic as get-locations.js)
-    var museumNames = new Set(settings.standaloneMuseums || []);
-    buckets.forEach(function (bucket) {
-      var commaIdx = bucket.key.indexOf(', ');
-      if (commaIdx !== -1) museumNames.add(bucket.key.substring(0, commaIdx));
-    });
+    // settings.museums is the definitive allowlist of valid museum names.
+    var validMuseums = new Set(settings.museums || []);
 
     // Collect categories per museum from all relevant buckets (both standalone
-    // and combined). This ensures e.g. Locomotion gets category+museum URLs
-    // even if all its objects are in galleries (no standalone bucket).
+    // and combined 'Museum, Gallery' entries) for valid museums only.
     var museumCategories = {};
-    museumNames.forEach(function (name) { museumCategories[name] = new Set(); });
+    validMuseums.forEach(function (name) { museumCategories[name] = new Set(); });
 
     buckets.forEach(function (bucket) {
       var commaIdx = bucket.key.indexOf(', ');
@@ -43,19 +38,20 @@ module.exports = (elastic, settings, sitemaps, cb) => {
       }
     });
 
-    // Generate category+museum URLs
-    museumNames.forEach(function (name) {
+    // Generate category+museum URLs for valid museums
+    validMuseums.forEach(function (name) {
       var mSlug = slug(name, { lower: true });
       museumCategories[name].forEach(function (catKey) {
         entries.push({ loc: `${settings.siteUrl}/search/categories/${slug(catKey, { lower: true })}/museum/${mSlug}` });
       });
     });
 
-    // Generate category+museum+gallery URLs from combined entries
+    // Generate category+museum+gallery URLs from combined entries for valid museums only
     buckets.forEach(function (bucket) {
       var commaIdx = bucket.key.indexOf(', ');
       if (commaIdx === -1) return;
       var museumName = bucket.key.substring(0, commaIdx);
+      if (!validMuseums.has(museumName)) return;
       var galleryName = bucket.key.substring(commaIdx + 2);
       var mSlug = slug(museumName, { lower: true });
       var gSlug = slug(galleryName, { lower: true });

--- a/lib/get-categories-at-locations.js
+++ b/lib/get-categories-at-locations.js
@@ -20,8 +20,10 @@ module.exports = (elastic, settings, sitemaps, cb) => {
     var buckets = data.body.aggregations.display_values.buckets;
     var entries = [];
 
-    // Pass 1: identify museum names from combined 'Museum, Gallery' entries
-    var museumNames = new Set();
+    // Pass 1: identify museum names from combined 'Museum, Gallery' entries,
+    // plus any explicitly listed standalone museums (e.g. Locomotion which has
+    // no individual gallery pages).
+    var museumNames = new Set(settings.standaloneMuseums || []);
     buckets.forEach(function (bucket) {
       var commaIdx = bucket.key.indexOf(', ');
       if (commaIdx !== -1) museumNames.add(bucket.key.substring(0, commaIdx));

--- a/lib/get-categories-at-locations.js
+++ b/lib/get-categories-at-locations.js
@@ -20,33 +20,48 @@ module.exports = (elastic, settings, sitemaps, cb) => {
     var buckets = data.body.aggregations.display_values.buckets;
     var entries = [];
 
-    // Pass 1: identify museum names from combined 'Museum, Gallery' entries,
-    // plus any explicitly listed standalone museums (e.g. Locomotion which has
-    // no individual gallery pages).
+    // Pass 1: identify museum names (same logic as get-locations.js)
     var museumNames = new Set(settings.standaloneMuseums || []);
     buckets.forEach(function (bucket) {
       var commaIdx = bucket.key.indexOf(', ');
       if (commaIdx !== -1) museumNames.add(bucket.key.substring(0, commaIdx));
     });
 
-    // Pass 2: generate category URLs for museum and museum+gallery combinations
+    // Collect categories per museum from all relevant buckets (both standalone
+    // and combined). This ensures e.g. Locomotion gets category+museum URLs
+    // even if all its objects are in galleries (no standalone bucket).
+    var museumCategories = {};
+    museumNames.forEach(function (name) { museumCategories[name] = new Set(); });
+
     buckets.forEach(function (bucket) {
-      var key = bucket.key;
-      var commaIdx = key.indexOf(', ');
-      var urlSuffix;
-
-      if (commaIdx === -1) {
-        if (!museumNames.has(key)) return; // standalone gallery name, skip
-        urlSuffix = `/museum/${slug(key, { lower: true })}`;
-      } else {
-        var museumName = key.substring(0, commaIdx);
-        var galleryName = key.substring(commaIdx + 2);
-        urlSuffix = `/museum/${slug(museumName, { lower: true })}/gallery/${slug(galleryName, { lower: true })}`;
+      var commaIdx = bucket.key.indexOf(', ');
+      var museumName = commaIdx === -1 ? bucket.key : bucket.key.substring(0, commaIdx);
+      if (museumCategories[museumName]) {
+        bucket.categories.buckets.forEach(function (catBucket) {
+          museumCategories[museumName].add(catBucket.key);
+        });
       }
+    });
 
+    // Generate category+museum URLs
+    museumNames.forEach(function (name) {
+      var mSlug = slug(name, { lower: true });
+      museumCategories[name].forEach(function (catKey) {
+        entries.push({ loc: `${settings.siteUrl}/search/categories/${slug(catKey, { lower: true })}/museum/${mSlug}` });
+      });
+    });
+
+    // Generate category+museum+gallery URLs from combined entries
+    buckets.forEach(function (bucket) {
+      var commaIdx = bucket.key.indexOf(', ');
+      if (commaIdx === -1) return;
+      var museumName = bucket.key.substring(0, commaIdx);
+      var galleryName = bucket.key.substring(commaIdx + 2);
+      var mSlug = slug(museumName, { lower: true });
+      var gSlug = slug(galleryName, { lower: true });
       bucket.categories.buckets.forEach(function (catBucket) {
         entries.push({
-          loc: `${settings.siteUrl}/search/categories/${slug(catBucket.key, { lower: true })}${urlSuffix}`
+          loc: `${settings.siteUrl}/search/categories/${slug(catBucket.key, { lower: true })}/museum/${mSlug}/gallery/${gSlug}`
         });
       });
     });

--- a/lib/get-collections.js
+++ b/lib/get-collections.js
@@ -1,0 +1,29 @@
+const slug = require('slug');
+
+module.exports = (elastic, settings, sitemaps, cb) => {
+  var collections = [];
+  var opts = {
+    body: {
+      size: 0,
+      aggregations: {
+        collection: {
+          terms: {
+            size: 1000,
+            field: 'cumulation.collector.summary.title.keyword'
+          }
+        }
+      }
+    }
+  };
+
+  elastic.search(opts, function (err, data) {
+    if (err) return cb(err);
+
+    data.body.aggregations.collection.buckets.forEach(el => {
+      const loc = `${settings.siteUrl}/search/collection/${slug(el.key, { lower: true })}`;
+      collections.push({ loc: loc });
+    });
+
+    return cb(null, sitemaps.concat(collections));
+  });
+};

--- a/lib/get-locations.js
+++ b/lib/get-locations.js
@@ -17,8 +17,10 @@ module.exports = (elastic, settings, sitemaps, cb) => {
     var buckets = data.body.aggregations.display_values.buckets;
     var entries = [];
 
-    // Pass 1: identify museum names from combined 'Museum, Gallery' entries
-    var museumNames = new Set();
+    // Pass 1: identify museum names from combined 'Museum, Gallery' entries,
+    // plus any explicitly listed standalone museums (e.g. Locomotion which has
+    // no individual gallery pages).
+    var museumNames = new Set(settings.standaloneMuseums || []);
     buckets.forEach(function (bucket) {
       var commaIdx = bucket.key.indexOf(', ');
       if (commaIdx !== -1) museumNames.add(bucket.key.substring(0, commaIdx));

--- a/lib/get-locations.js
+++ b/lib/get-locations.js
@@ -17,26 +17,23 @@ module.exports = (elastic, settings, sitemaps, cb) => {
     var buckets = data.body.aggregations.display_values.buckets;
     var entries = [];
 
-    // Pass 1: identify museum names from combined 'Museum, Gallery' entries,
-    // plus any explicitly listed standaloneMuseums. This ensures museums like
-    // Locomotion get a top-level museum URL even if all their objects are
-    // assigned to specific galleries (so no standalone bucket exists).
-    var museumNames = new Set(settings.standaloneMuseums || []);
-    buckets.forEach(function (bucket) {
-      var commaIdx = bucket.key.indexOf(', ');
-      if (commaIdx !== -1) museumNames.add(bucket.key.substring(0, commaIdx));
-    });
+    // settings.museums is the definitive allowlist of valid museum names.
+    // Only these museums get top-level /search/museum/<slug> URLs, preventing
+    // non-museum locations (e.g. 'Science and Innovation Park') from being
+    // included. Museum names must match the exact ondisplay.value.keyword value.
+    var validMuseums = new Set(settings.museums || []);
 
-    // Generate a museum-level URL for every identified museum
-    museumNames.forEach(function (name) {
+    // Generate a museum-level URL for each valid museum
+    validMuseums.forEach(function (name) {
       entries.push({ loc: `${settings.siteUrl}/search/museum/${slug(name, { lower: true })}` });
     });
 
-    // Generate museum+gallery URLs from combined entries
+    // Generate museum+gallery URLs from combined entries for valid museums only
     buckets.forEach(function (bucket) {
       var commaIdx = bucket.key.indexOf(', ');
-      if (commaIdx === -1) return; // standalone entries don't drive gallery URLs
+      if (commaIdx === -1) return;
       var museumName = bucket.key.substring(0, commaIdx);
+      if (!validMuseums.has(museumName)) return;
       var galleryName = bucket.key.substring(commaIdx + 2);
       entries.push({ loc: `${settings.siteUrl}/search/museum/${slug(museumName, { lower: true })}/gallery/${slug(galleryName, { lower: true })}` });
     });

--- a/lib/get-locations.js
+++ b/lib/get-locations.js
@@ -18,29 +18,27 @@ module.exports = (elastic, settings, sitemaps, cb) => {
     var entries = [];
 
     // Pass 1: identify museum names from combined 'Museum, Gallery' entries,
-    // plus any explicitly listed standalone museums (e.g. Locomotion which has
-    // no individual gallery pages).
+    // plus any explicitly listed standaloneMuseums. This ensures museums like
+    // Locomotion get a top-level museum URL even if all their objects are
+    // assigned to specific galleries (so no standalone bucket exists).
     var museumNames = new Set(settings.standaloneMuseums || []);
     buckets.forEach(function (bucket) {
       var commaIdx = bucket.key.indexOf(', ');
       if (commaIdx !== -1) museumNames.add(bucket.key.substring(0, commaIdx));
     });
 
-    // Pass 2: generate museum and museum+gallery URLs
-    buckets.forEach(function (bucket) {
-      var key = bucket.key;
-      var commaIdx = key.indexOf(', ');
+    // Generate a museum-level URL for every identified museum
+    museumNames.forEach(function (name) {
+      entries.push({ loc: `${settings.siteUrl}/search/museum/${slug(name, { lower: true })}` });
+    });
 
-      if (commaIdx === -1) {
-        if (!museumNames.has(key)) return; // standalone gallery name, skip
-        entries.push({ loc: `${settings.siteUrl}/search/museum/${slug(key, { lower: true })}` });
-      } else {
-        var museumName = key.substring(0, commaIdx);
-        var galleryName = key.substring(commaIdx + 2);
-        var mSlug = slug(museumName, { lower: true });
-        var gSlug = slug(galleryName, { lower: true });
-        entries.push({ loc: `${settings.siteUrl}/search/museum/${mSlug}/gallery/${gSlug}` });
-      }
+    // Generate museum+gallery URLs from combined entries
+    buckets.forEach(function (bucket) {
+      var commaIdx = bucket.key.indexOf(', ');
+      if (commaIdx === -1) return; // standalone entries don't drive gallery URLs
+      var museumName = bucket.key.substring(0, commaIdx);
+      var galleryName = bucket.key.substring(commaIdx + 2);
+      entries.push({ loc: `${settings.siteUrl}/search/museum/${slug(museumName, { lower: true })}/gallery/${slug(galleryName, { lower: true })}` });
     });
 
     return cb(null, sitemaps.concat(entries));

--- a/settings.json.template
+++ b/settings.json.template
@@ -9,7 +9,7 @@
     "host": "",
     "log": "error"
   },
-  "standaloneMuseums": ["Science Museum", "Science and Industry Museum", "National Science and Media Museum", "National Railway Museum", "Locomotion"],
+  "museums": ["Science Museum", "Science and Industry Museum", "National Science and Media Museum", "National Railway Museum", "Locomotion"],
   "s3": {
     "region": "eu-west-1",
     "accessKeyId": "",

--- a/settings.json.template
+++ b/settings.json.template
@@ -9,7 +9,7 @@
     "host": "",
     "log": "error"
   },
-  "standaloneMuseums": ["Locomotion"],
+  "standaloneMuseums": ["Science Museum", "Science and Industry Museum", "National Science and Media Museum", "National Railway Museum", "Locomotion"],
   "s3": {
     "region": "eu-west-1",
     "accessKeyId": "",

--- a/settings.json.template
+++ b/settings.json.template
@@ -1,5 +1,6 @@
 {
   "siteUrl": "http://localhost:8000",
+  "imageSiteUrl": "https://coimages.sciencemuseumgroup.org.uk",
   "sitemapUrl": "http://localhost:8000",
   "maxSitemapUrls": 50000,
   "pageSize": 10000,

--- a/settings.json.template
+++ b/settings.json.template
@@ -2,7 +2,7 @@
   "siteUrl": "http://localhost:8000",
   "imageSiteUrl": "https://coimages.sciencemuseumgroup.org.uk",
   "sitemapUrl": "http://localhost:8000",
-  "maxSitemapUrls": 50000,
+  "maxSitemapUrls": 10000,
   "pageSize": 10000,
   "tmpDir": "/tmp",
   "elasticsearch": {

--- a/settings.json.template
+++ b/settings.json.template
@@ -9,6 +9,7 @@
     "host": "",
     "log": "error"
   },
+  "standaloneMuseums": ["Locomotion"],
   "s3": {
     "region": "eu-west-1",
     "accessKeyId": "",

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -33,6 +33,7 @@ test('Should generate and upload sitemap.xml', (t) => {
   const catResult = () => ({body: {aggregations: {category: {buckets: [{key: 'Surgery', doc_count: 1}]}}}});
   const locResult = () => ({body: {aggregations: {display_values: {buckets: [{key: 'Science Museum', doc_count: 5}, {key: 'Science Museum, Energy Hall', doc_count: 2}]}}}});
   const locCatResult = () => ({body: {aggregations: {display_values: {buckets: [{key: 'Science Museum', doc_count: 5, categories: {buckets: [{key: 'Robots', doc_count: 3}]}}, {key: 'Science Museum, Energy Hall', doc_count: 2, categories: {buckets: [{key: 'Robots', doc_count: 2}]}}]}}}});
+  const colResult = () => ({body: {aggregations: {collection: {buckets: [{key: 'Flight Collection', doc_count: 42}]}}}});
 
   // First result on initial call
   mockElastic.expects('search')
@@ -46,6 +47,10 @@ test('Should generate and upload sitemap.xml', (t) => {
   mockElastic.expects('search')
     .exactly(1)
     .callsArgWithAsync(1, null, locCatResult());
+
+  mockElastic.expects('search')
+    .exactly(1)
+    .callsArgWithAsync(1, null, colResult());
 
   mockElastic.expects('search')
     .exactly(1)

--- a/test/key-serps.test.js
+++ b/test/key-serps.test.js
@@ -34,9 +34,9 @@ test('Should get key serp pages', (t) => {
   });
 
   // get-locations.js: ondisplay.value.keyword aggregation
-  // includes a standalone museum, a combined 'Museum, Gallery' entry,
-  // a standalone gallery (should be skipped), and Locomotion (standalone museum
-  // with no gallery sub-entries, included via settings.standaloneMuseums)
+  // Locomotion only appears as a combined 'Locomotion, Main Hall' entry — there
+  // is no standalone 'Locomotion' bucket. The standaloneMuseums setting ensures
+  // a top-level museum URL is still generated.
   const locResult = () => ({
     body: {
       aggregations: {
@@ -45,7 +45,7 @@ test('Should get key serp pages', (t) => {
             { key: 'Science Museum', doc_count: 12556 },
             { key: 'Science Museum, Energy Hall', doc_count: 2335 },
             { key: 'Energy Hall', doc_count: 2335 }, // standalone gallery — should be skipped
-            { key: 'Locomotion', doc_count: 500 } // standalone museum via standaloneMuseums setting
+            { key: 'Locomotion, Main Hall', doc_count: 500 } // Locomotion only appears with a gallery
           ]
         }
       }
@@ -74,7 +74,7 @@ test('Should get key serp pages', (t) => {
               categories: { buckets: [{ key: 'Robots', doc_count: 2 }] }
             },
             {
-              key: 'Locomotion', // standalone museum via standaloneMuseums setting
+              key: 'Locomotion, Main Hall', // Locomotion only appears with a gallery
               doc_count: 500,
               categories: { buckets: [{ key: 'Robots', doc_count: 1 }] }
             }
@@ -107,8 +107,10 @@ test('Should get key serp pages', (t) => {
     t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/science-museum'), 'Category+museum URL is correct');
     t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/science-museum/gallery/energy-hall'), 'Category+museum+gallery URL is correct');
     t.notOk(data.find(el => el.loc === 'http://localhost/search/museum/energy-hall'), 'Standalone gallery is not a top-level museum URL');
-    t.ok(data.find(el => el.loc === 'http://localhost/search/museum/locomotion'), 'Standalone museum (Locomotion) gets a museum URL');
-    t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/locomotion'), 'Standalone museum (Locomotion) gets a category+museum URL');
+    t.ok(data.find(el => el.loc === 'http://localhost/search/museum/locomotion'), 'Locomotion gets a top-level museum URL even with no standalone bucket');
+    t.ok(data.find(el => el.loc === 'http://localhost/search/museum/locomotion/gallery/main-hall'), 'Locomotion gets a museum+gallery URL');
+    t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/locomotion'), 'Locomotion gets a category+museum URL derived from its gallery entries');
+    t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/locomotion/gallery/main-hall'), 'Locomotion gets a category+museum+gallery URL');
 
     t.end();
   });

--- a/test/key-serps.test.js
+++ b/test/key-serps.test.js
@@ -90,6 +90,15 @@ test('Should get key serp pages', (t) => {
     }
   });
 
+  // get-collections.js: cumulation.collector.summary.title.keyword aggregation
+  const colResult = () => ({
+    body: {
+      aggregations: {
+        collection: { buckets: [{ key: 'Flight Collection', doc_count: 42 }] }
+      }
+    }
+  });
+
   mockElastic.expects('search')
     .exactly(1)
     .callsArgWithAsync(1, null, catResult());
@@ -101,6 +110,10 @@ test('Should get key serp pages', (t) => {
   mockElastic.expects('search')
     .exactly(1)
     .callsArgWithAsync(1, null, locCatResult());
+
+  mockElastic.expects('search')
+    .exactly(1)
+    .callsArgWithAsync(1, null, colResult());
 
   addKeySerps(elastic, testSettings, [], (err, data) => {
     t.ifError(err, 'Results added successfully');
@@ -118,6 +131,7 @@ test('Should get key serp pages', (t) => {
     t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/locomotion'), 'Locomotion gets a category+museum URL derived from its gallery entries');
     t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/locomotion/gallery/main-hall'), 'Locomotion gets a category+museum+gallery URL');
     t.notOk(data.find(el => el.loc.includes('science-and-innovation-park')), 'Non-allowlisted location is excluded entirely');
+    t.ok(data.find(el => el.loc === 'http://localhost/search/collection/flight-collection'), 'Collection URL is correct');
 
     t.end();
   });

--- a/test/key-serps.test.js
+++ b/test/key-serps.test.js
@@ -9,6 +9,7 @@ test('Should get key serp pages', (t) => {
     sitemapUrl: 'http://localhost',
     pageSize: 1,
     maxSitemapUrls: 2,
+    standaloneMuseums: ['Locomotion'],
     elasticsearch: {
       apiVersion: 5.4,
       host: 'http://localhost'
@@ -33,7 +34,9 @@ test('Should get key serp pages', (t) => {
   });
 
   // get-locations.js: ondisplay.value.keyword aggregation
-  // includes a standalone museum and a combined 'Museum, Gallery' entry
+  // includes a standalone museum, a combined 'Museum, Gallery' entry,
+  // a standalone gallery (should be skipped), and Locomotion (standalone museum
+  // with no gallery sub-entries, included via settings.standaloneMuseums)
   const locResult = () => ({
     body: {
       aggregations: {
@@ -41,7 +44,8 @@ test('Should get key serp pages', (t) => {
           buckets: [
             { key: 'Science Museum', doc_count: 12556 },
             { key: 'Science Museum, Energy Hall', doc_count: 2335 },
-            { key: 'Energy Hall', doc_count: 2335 } // standalone gallery — should be skipped
+            { key: 'Energy Hall', doc_count: 2335 }, // standalone gallery — should be skipped
+            { key: 'Locomotion', doc_count: 500 } // standalone museum via standaloneMuseums setting
           ]
         }
       }
@@ -68,6 +72,11 @@ test('Should get key serp pages', (t) => {
               key: 'Energy Hall', // standalone gallery — should be skipped
               doc_count: 2335,
               categories: { buckets: [{ key: 'Robots', doc_count: 2 }] }
+            },
+            {
+              key: 'Locomotion', // standalone museum via standaloneMuseums setting
+              doc_count: 500,
+              categories: { buckets: [{ key: 'Robots', doc_count: 1 }] }
             }
           ]
         }
@@ -98,6 +107,8 @@ test('Should get key serp pages', (t) => {
     t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/science-museum'), 'Category+museum URL is correct');
     t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/science-museum/gallery/energy-hall'), 'Category+museum+gallery URL is correct');
     t.notOk(data.find(el => el.loc === 'http://localhost/search/museum/energy-hall'), 'Standalone gallery is not a top-level museum URL');
+    t.ok(data.find(el => el.loc === 'http://localhost/search/museum/locomotion'), 'Standalone museum (Locomotion) gets a museum URL');
+    t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/locomotion'), 'Standalone museum (Locomotion) gets a category+museum URL');
 
     t.end();
   });

--- a/test/key-serps.test.js
+++ b/test/key-serps.test.js
@@ -9,7 +9,7 @@ test('Should get key serp pages', (t) => {
     sitemapUrl: 'http://localhost',
     pageSize: 1,
     maxSitemapUrls: 2,
-    standaloneMuseums: ['Locomotion'],
+    museums: ['Science Museum', 'Locomotion'],
     elasticsearch: {
       apiVersion: 5.4,
       host: 'http://localhost'
@@ -45,7 +45,8 @@ test('Should get key serp pages', (t) => {
             { key: 'Science Museum', doc_count: 12556 },
             { key: 'Science Museum, Energy Hall', doc_count: 2335 },
             { key: 'Energy Hall', doc_count: 2335 }, // standalone gallery — should be skipped
-            { key: 'Locomotion, Main Hall', doc_count: 500 } // Locomotion only appears with a gallery
+            { key: 'Locomotion, Main Hall', doc_count: 500 }, // Locomotion appears as combined entry
+            { key: 'Science and Innovation Park, Welcome Building', doc_count: 4 } // not in museums allowlist — should be skipped
           ]
         }
       }
@@ -74,8 +75,13 @@ test('Should get key serp pages', (t) => {
               categories: { buckets: [{ key: 'Robots', doc_count: 2 }] }
             },
             {
-              key: 'Locomotion, Main Hall', // Locomotion only appears with a gallery
+              key: 'Locomotion, Main Hall', // Locomotion appears as combined entry
               doc_count: 500,
+              categories: { buckets: [{ key: 'Robots', doc_count: 1 }] }
+            },
+            {
+              key: 'Science and Innovation Park, Welcome Building', // not in museums allowlist
+              doc_count: 4,
               categories: { buckets: [{ key: 'Robots', doc_count: 1 }] }
             }
           ]
@@ -111,6 +117,7 @@ test('Should get key serp pages', (t) => {
     t.ok(data.find(el => el.loc === 'http://localhost/search/museum/locomotion/gallery/main-hall'), 'Locomotion gets a museum+gallery URL');
     t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/locomotion'), 'Locomotion gets a category+museum URL derived from its gallery entries');
     t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/locomotion/gallery/main-hall'), 'Locomotion gets a category+museum+gallery URL');
+    t.notOk(data.find(el => el.loc.includes('science-and-innovation-park')), 'Non-allowlisted location is excluded entirely');
 
     t.end();
   });


### PR DESCRIPTION
## Summary

The existing location logic identified museum names only from standalone `\"Museum\"` ES buckets. Museums like Locomotion only appear in combined `\"Museum, Gallery\"` entries (e.g. `\"Locomotion, Main Hall\"`), so their top-level museum URL was silently skipped.

Replaces the bucket-driven museum detection with a `museums` setting — an explicit allowlist of museum names. Both `get-locations.js` and `get-categories-at-locations.js` use this list, so all 5 SMG museums correctly get:

- `/search/museum/<museum>` — top-level museum page
- `/search/museum/<museum>/gallery/<gallery>` — individual gallery pages (where they exist in ES)
- `/search/categories/<category>/museum/<museum>` — category+museum pages
- `/search/categories/<category>/museum/<museum>/gallery/<gallery>` — category+museum+gallery pages

Non-museum locations (e.g. `Science and Innovation Park`) are excluded entirely.

Also adds a `get-collections.js` step querying `cumulation.collector.summary.title.keyword` to generate `/search/collection/<slug>` entries for named collections.

`settings.json.template` updated with all 5 museums, `imageSiteUrl`, and `maxSitemapUrls: 10000`.

## Test plan

- [x] 75/75 tests pass
- [x] `Locomotion gets a top-level museum URL even with no standalone bucket`
- [x] `Locomotion gets a museum+gallery URL`
- [x] `Locomotion gets a category+museum URL derived from its gallery entries`
- [x] `Locomotion gets a category+museum+gallery URL`
- [x] `Non-allowlisted location is excluded entirely`
- [x] `Collection URL is correct`
- [x] `Standalone gallery is not a top-level museum URL` (existing behaviour preserved)
- [ ] Verify all museum, gallery, and collection URLs appear in generated sitemap