### PR TITLE
Fix apostrophe stripping in SERP sitemap URLs

### DIFF
--- a/lib/get-categories-at-locations.js
+++ b/lib/get-categories-at-locations.js
@@ -1,5 +1,3 @@
-var slug = require('slug');
-
 module.exports = (elastic, settings, sitemaps, cb) => {
   var opts = {
     body: {
@@ -38,11 +36,13 @@ module.exports = (elastic, settings, sitemaps, cb) => {
       }
     });
 
+    var toUrlPart = function (s) { return s.toLowerCase().replace(/\s+/g, '-'); };
+
     // Generate category+museum URLs for valid museums
     validMuseums.forEach(function (name) {
-      var mSlug = slug(name, { lower: true });
+      var mSlug = toUrlPart(name);
       museumCategories[name].forEach(function (catKey) {
-        entries.push({ loc: `${settings.siteUrl}/search/categories/${slug(catKey, { lower: true })}/museum/${mSlug}` });
+        entries.push({ loc: `${settings.siteUrl}/search/categories/${toUrlPart(catKey)}/museum/${mSlug}` });
       });
     });
 
@@ -53,11 +53,11 @@ module.exports = (elastic, settings, sitemaps, cb) => {
       var museumName = bucket.key.substring(0, commaIdx);
       if (!validMuseums.has(museumName)) return;
       var galleryName = bucket.key.substring(commaIdx + 2);
-      var mSlug = slug(museumName, { lower: true });
-      var gSlug = slug(galleryName, { lower: true });
+      var mSlug = toUrlPart(museumName);
+      var gSlug = toUrlPart(galleryName);
       bucket.categories.buckets.forEach(function (catBucket) {
         entries.push({
-          loc: `${settings.siteUrl}/search/categories/${slug(catBucket.key, { lower: true })}/museum/${mSlug}/gallery/${gSlug}`
+          loc: `${settings.siteUrl}/search/categories/${toUrlPart(catBucket.key)}/museum/${mSlug}/gallery/${gSlug}`
         });
       });
     });

--- a/lib/get-collections.js
+++ b/lib/get-collections.js
@@ -1,5 +1,3 @@
-const slug = require('slug');
-
 module.exports = (elastic, settings, sitemaps, cb) => {
   var collections = [];
   var opts = {
@@ -20,7 +18,7 @@ module.exports = (elastic, settings, sitemaps, cb) => {
     if (err) return cb(err);
 
     data.body.aggregations.collection.buckets.forEach(el => {
-      const loc = `${settings.siteUrl}/search/collection/${slug(el.key, { lower: true })}`;
+      const loc = `${settings.siteUrl}/search/collection/${el.key.toLowerCase().replace(/\s+/g, '-')}`;
       collections.push({ loc: loc });
     });
 

--- a/lib/get-locations.js
+++ b/lib/get-locations.js
@@ -1,5 +1,3 @@
-var slug = require('slug');
-
 module.exports = (elastic, settings, sitemaps, cb) => {
   var opts = {
     body: {
@@ -25,7 +23,7 @@ module.exports = (elastic, settings, sitemaps, cb) => {
 
     // Generate a museum-level URL for each valid museum
     validMuseums.forEach(function (name) {
-      entries.push({ loc: `${settings.siteUrl}/search/museum/${slug(name, { lower: true })}` });
+      entries.push({ loc: `${settings.siteUrl}/search/museum/${name.toLowerCase().replace(/\s+/g, '-')}` });
     });
 
     // Generate museum+gallery URLs from combined entries for valid museums only
@@ -35,7 +33,7 @@ module.exports = (elastic, settings, sitemaps, cb) => {
       var museumName = bucket.key.substring(0, commaIdx);
       if (!validMuseums.has(museumName)) return;
       var galleryName = bucket.key.substring(commaIdx + 2);
-      entries.push({ loc: `${settings.siteUrl}/search/museum/${slug(museumName, { lower: true })}/gallery/${slug(galleryName, { lower: true })}` });
+      entries.push({ loc: `${settings.siteUrl}/search/museum/${museumName.toLowerCase().replace(/\s+/g, '-')}/gallery/${galleryName.toLowerCase().replace(/\s+/g, '-')}` });
     });
 
     return cb(null, sitemaps.concat(entries));

--- a/test/key-serps.test.js
+++ b/test/key-serps.test.js
@@ -44,6 +44,7 @@ test('Should get key serp pages', (t) => {
           buckets: [
             { key: 'Science Museum', doc_count: 12556 },
             { key: 'Science Museum, Energy Hall', doc_count: 2335 },
+            { key: 'Science Museum, Clockmakers\' Museum Gallery', doc_count: 150 }, // apostrophe in gallery name
             { key: 'Energy Hall', doc_count: 2335 }, // standalone gallery — should be skipped
             { key: 'Locomotion, Main Hall', doc_count: 500 }, // Locomotion appears as combined entry
             { key: 'Science and Innovation Park, Welcome Building', doc_count: 4 } // not in museums allowlist — should be skipped
@@ -68,6 +69,11 @@ test('Should get key serp pages', (t) => {
               key: 'Science Museum, Energy Hall',
               doc_count: 2335,
               categories: { buckets: [{ key: 'Robots', doc_count: 2 }] }
+            },
+            {
+              key: 'Science Museum, Clockmakers\' Museum Gallery',
+              doc_count: 150,
+              categories: { buckets: [{ key: 'Horology', doc_count: 150 }] }
             },
             {
               key: 'Energy Hall', // standalone gallery — should be skipped
@@ -132,6 +138,8 @@ test('Should get key serp pages', (t) => {
     t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/locomotion/gallery/main-hall'), 'Locomotion gets a category+museum+gallery URL');
     t.notOk(data.find(el => el.loc.includes('science-and-innovation-park')), 'Non-allowlisted location is excluded entirely');
     t.ok(data.find(el => el.loc === 'http://localhost/search/collection/flight-collection'), 'Collection URL is correct');
+    t.ok(data.find(el => el.loc === "http://localhost/search/museum/science-museum/gallery/clockmakers'-museum-gallery"), "Apostrophe in gallery name is preserved in URL");
+    t.ok(data.find(el => el.loc === "http://localhost/search/categories/horology/museum/science-museum/gallery/clockmakers'-museum-gallery"), "Apostrophe preserved in category+museum+gallery URL");
 
     t.end();
   });


### PR DESCRIPTION
## Summary

Gallery names containing apostrophes (e.g. \`Clockmakers' Museum Gallery\`) were generating broken sitemap URLs because the \`slug()\` npm library strips non-alphanumeric characters:

- **Broken** (sitemap): \`/search/museum/science-museum/gallery/clockmakers-museum-gallery\` → no results
- **Correct** (website): \`/search/museum/science-museum/gallery/clockmakers'-museum-gallery\` → results shown

Replaces \`slug(name, {lower: true})\` with \`name.toLowerCase().replace(/\s+/g, '-')\` in \`get-locations.js\`, \`get-categories-at-locations.js\`, and \`get-collections.js\` to match website URL encoding. \`get-categories.js\` was already correct.

## Test plan

- [x] 78/78 tests pass
- [x] Apostrophe in gallery name is preserved in URL
- [x] Apostrophe preserved in category+museum+gallery URL
- [ ] Verify \`clockmakers'-museum-gallery\` appears correctly in generated sitemap