### PR TITLE
feat: use lossless encode-filter-value for all sitemap URL generation

### DIFF
--- a/lib/encode-filter-value.js
+++ b/lib/encode-filter-value.js
@@ -1,0 +1,24 @@
+/**
+ * Encodes a filter value for use in a URL path segment.
+ *
+ * Encoding scheme:
+ *   space  → -        (human-readable, SEO-friendly)
+ *   hyphen → %252D    (double-encoded so Hapi's %25→% pass leaves %2D,
+ *                      then decodeURIComponent restores the hyphen)
+ *   slash  → %252F    (same double-encoding scheme)
+ *   comma  → %252C    (same double-encoding scheme)
+ *
+ * This must match the encodeFilterValue helper in the main collectionsonline app
+ * (lib/helpers/encode-filter-value.js) so sitemap URLs round-trip correctly.
+ *
+ * @param {string} value - Raw filter value from Elasticsearch (e.g. "Burgoyne-Johnson Collection")
+ * @returns {string} URL-safe path segment
+ */
+module.exports = function encodeFilterValue (value) {
+  return value
+    .replace(/-/g, '%252D') // encode hyphens before spaces become dashes
+    .replace(/\//g, '%252F') // encode slashes
+    .replace(/,/g, '%252C') // encode commas
+    .replace(/\s+/g, '-') // spaces → dashes (human-readable)
+    .toLowerCase();
+};

--- a/lib/get-categories-at-locations.js
+++ b/lib/get-categories-at-locations.js
@@ -1,3 +1,5 @@
+const encodeFilterValue = require('./encode-filter-value');
+
 module.exports = (elastic, settings, sitemaps, cb) => {
   var opts = {
     body: {
@@ -36,7 +38,7 @@ module.exports = (elastic, settings, sitemaps, cb) => {
       }
     });
 
-    var toUrlPart = function (s) { return s.toLowerCase().replace(/\s+/g, '-'); };
+    var toUrlPart = encodeFilterValue;
 
     // Generate category+museum URLs for valid museums
     validMuseums.forEach(function (name) {

--- a/lib/get-categories.js
+++ b/lib/get-categories.js
@@ -1,3 +1,5 @@
+const encodeFilterValue = require('./encode-filter-value');
+
 module.exports = (elastic, settings, sitemaps, cb) => {
   var categories = [];
   var opts = {
@@ -18,7 +20,7 @@ module.exports = (elastic, settings, sitemaps, cb) => {
     if (err) return cb(err);
 
     data.body.aggregations.category.buckets.forEach(el => {
-      const loc = `${settings.siteUrl}/search/categories/${el.key.split(' ').join('-').toLowerCase()}`;
+      const loc = `${settings.siteUrl}/search/categories/${encodeFilterValue(el.key)}`;
       categories.push({loc: loc});
     });
 

--- a/lib/get-collections.js
+++ b/lib/get-collections.js
@@ -1,3 +1,5 @@
+const encodeFilterValue = require('./encode-filter-value');
+
 module.exports = (elastic, settings, sitemaps, cb) => {
   var collections = [];
   var opts = {
@@ -18,7 +20,7 @@ module.exports = (elastic, settings, sitemaps, cb) => {
     if (err) return cb(err);
 
     data.body.aggregations.collection.buckets.forEach(el => {
-      const loc = `${settings.siteUrl}/search/collection/${el.key.toLowerCase().replace(/\s+/g, '-')}`;
+      const loc = `${settings.siteUrl}/search/collection/${encodeFilterValue(el.key)}`;
       collections.push({ loc: loc });
     });
 

--- a/lib/get-locations.js
+++ b/lib/get-locations.js
@@ -1,3 +1,5 @@
+const encodeFilterValue = require('./encode-filter-value');
+
 module.exports = (elastic, settings, sitemaps, cb) => {
   var opts = {
     body: {
@@ -23,7 +25,7 @@ module.exports = (elastic, settings, sitemaps, cb) => {
 
     // Generate a museum-level URL for each valid museum
     validMuseums.forEach(function (name) {
-      entries.push({ loc: `${settings.siteUrl}/search/museum/${name.toLowerCase().replace(/\s+/g, '-')}` });
+      entries.push({ loc: `${settings.siteUrl}/search/museum/${encodeFilterValue(name)}` });
     });
 
     // Generate museum+gallery URLs from combined entries for valid museums only
@@ -33,7 +35,7 @@ module.exports = (elastic, settings, sitemaps, cb) => {
       var museumName = bucket.key.substring(0, commaIdx);
       if (!validMuseums.has(museumName)) return;
       var galleryName = bucket.key.substring(commaIdx + 2);
-      entries.push({ loc: `${settings.siteUrl}/search/museum/${museumName.toLowerCase().replace(/\s+/g, '-')}/gallery/${galleryName.toLowerCase().replace(/\s+/g, '-')}` });
+      entries.push({ loc: `${settings.siteUrl}/search/museum/${encodeFilterValue(museumName)}/gallery/${encodeFilterValue(galleryName)}` });
     });
 
     return cb(null, sitemaps.concat(entries));

--- a/test/encode-filter-value.test.js
+++ b/test/encode-filter-value.test.js
@@ -1,0 +1,35 @@
+const test = require('tape');
+const encodeFilterValue = require('../lib/encode-filter-value');
+
+test('encodeFilterValue: spaces become dashes', function (t) {
+  t.equal(encodeFilterValue('Flight Collection'), 'flight-collection');
+  t.end();
+});
+
+test('encodeFilterValue: hyphens become %252D', function (t) {
+  t.equal(encodeFilterValue('Burgoyne-Johnson Collection'), 'burgoyne%252djohnson-collection');
+  t.end();
+});
+
+test('encodeFilterValue: slashes become %252F', function (t) {
+  t.equal(encodeFilterValue('Buckingham Movie Museum/John Smith'), 'buckingham-movie-museum%252fjohn-smith');
+  t.end();
+});
+
+test('encodeFilterValue: commas become %252C', function (t) {
+  t.equal(encodeFilterValue('People, Pride and Progress'), 'people%252c-pride-and-progress');
+  t.end();
+});
+
+test('encodeFilterValue: combined special characters', function (t) {
+  t.equal(
+    encodeFilterValue('Buckingham Movie Museum/John Burgoyne-Johnson Collection'),
+    'buckingham-movie-museum%252fjohn-burgoyne%252djohnson-collection'
+  );
+  t.end();
+});
+
+test('encodeFilterValue: output is lowercase', function (t) {
+  t.equal(encodeFilterValue('Science Museum'), 'science-museum');
+  t.end();
+});

--- a/test/handler.test.js
+++ b/test/handler.test.js
@@ -33,7 +33,8 @@ test('Should generate and upload sitemap.xml', (t) => {
   const catResult = () => ({body: {aggregations: {category: {buckets: [{key: 'Surgery', doc_count: 1}]}}}});
   const locResult = () => ({body: {aggregations: {display_values: {buckets: [{key: 'Science Museum', doc_count: 5}, {key: 'Science Museum, Energy Hall', doc_count: 2}]}}}});
   const locCatResult = () => ({body: {aggregations: {display_values: {buckets: [{key: 'Science Museum', doc_count: 5, categories: {buckets: [{key: 'Robots', doc_count: 3}]}}, {key: 'Science Museum, Energy Hall', doc_count: 2, categories: {buckets: [{key: 'Robots', doc_count: 2}]}}]}}}});
-  const colResult = () => ({body: {aggregations: {collection: {buckets: [{key: 'Flight Collection', doc_count: 42}]}}}});
+  // Use a collection name with a hyphen and comma to verify %252D/%252C encoding
+  const colResult = () => ({body: {aggregations: {collection: {buckets: [{key: 'Burgoyne-Johnson Collection', doc_count: 42}, {key: 'People, Pride and Progress', doc_count: 9}]}}}});
 
   // Key SERP searches: categories, locations, categoriesAtLocations, collections
   mockElastic.expects('search').exactly(1).callsArgWithAsync(1, null, catResult());

--- a/test/key-serps.test.js
+++ b/test/key-serps.test.js
@@ -100,7 +100,13 @@ test('Should get key serp pages', (t) => {
   const colResult = () => ({
     body: {
       aggregations: {
-        collection: { buckets: [{ key: 'Flight Collection', doc_count: 42 }] }
+        collection: {
+          buckets: [
+            { key: 'Flight Collection', doc_count: 42 },
+            { key: 'Burgoyne-Johnson Collection', doc_count: 7 },
+            { key: 'People, Pride and Progress', doc_count: 9 }
+          ]
+        }
       }
     }
   });
@@ -138,6 +144,8 @@ test('Should get key serp pages', (t) => {
     t.ok(data.find(el => el.loc === 'http://localhost/search/categories/robots/museum/locomotion/gallery/main-hall'), 'Locomotion gets a category+museum+gallery URL');
     t.notOk(data.find(el => el.loc.includes('science-and-innovation-park')), 'Non-allowlisted location is excluded entirely');
     t.ok(data.find(el => el.loc === 'http://localhost/search/collection/flight-collection'), 'Collection URL is correct');
+    t.ok(data.find(el => el.loc === 'http://localhost/search/collection/burgoyne%252djohnson-collection'), 'Hyphen in collection name is encoded as %252D');
+    t.ok(data.find(el => el.loc === 'http://localhost/search/collection/people%252c-pride-and-progress'), 'Comma in collection name is encoded as %252C');
     t.ok(data.find(el => el.loc === "http://localhost/search/museum/science-museum/gallery/clockmakers'-museum-gallery"), "Apostrophe in gallery name is preserved in URL");
     t.ok(data.find(el => el.loc === "http://localhost/search/categories/horology/museum/science-museum/gallery/clockmakers'-museum-gallery"), "Apostrophe preserved in category+museum+gallery URL");
 


### PR DESCRIPTION
## Summary

Add `encode-filter-value.js` (mirrors the encoding in the main `collectionsonline` app) so generated sitemap URLs match the new encoding scheme.

Previously all four lib files used `.toLowerCase().replace(/\s+/g, '-')` which generated broken URLs for any filter value containing a hyphen or comma.

### Encoding scheme

| Character | Encoded as |
|---|---|
| space | `-` (unchanged) |
| hyphen | `%252D` |
| slash | `%252F` (unchanged) |
| comma | `%252C` |

### Files changed

- `lib/encode-filter-value.js` (new)
- `lib/get-collections.js`
- `lib/get-categories.js`
- `lib/get-locations.js`
- `lib/get-categories-at-locations.js` (`toUrlPart` replaced by `encodeFilterValue`)
- `test/encode-filter-value.test.js` (new unit tests)
- `test/handler.test.js` (hyphenated/comma collection names in fixture)
- `test/key-serps.test.js` (assertions for `%252D` and `%252C` encoding)

## Test plan

- [ ] All 86 unit tests pass (`npm test`)

> **Coordinated deployment required:** deploy alongside or shortly after [collectionsonline PR #2060](https://github.com/TheScienceMuseum/collectionsonline/pull/2060) so sitemap URLs match the new app encoding.